### PR TITLE
fix headers deprecation warning 

### DIFF
--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env node --no-deprecation
 
 /* IMPORT */
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -101,8 +101,7 @@ function initLocalConfig () {
 
     } else {
 
-      _.mergeWith ( Config, localConfig, ( prev, next, key ) => {
-        if ( key === 'downloads' ) return { ...next, path: path.resolve ( next.downloads.path ) }
+      _.mergeWith ( Config, localConfig, ( prev, next ) => {
         if ( !_.isArray ( prev ) || !_.isArray ( next ) ) return;
         return next;
       });

--- a/src/config.ts
+++ b/src/config.ts
@@ -101,7 +101,8 @@ function initLocalConfig () {
 
     } else {
 
-      _.mergeWith ( Config, localConfig, ( prev, next ) => {
+      _.mergeWith ( Config, localConfig, ( prev, next, key ) => {
+        if ( key === 'downloads' ) return { ...next, path: path.resolve ( next.downloads.path ) }
         if ( !_.isArray ( prev ) || !_.isArray ( next ) ) return;
         return next;
       });


### PR DESCRIPTION
closes #41 

some  dependencies are using a deprecated req field `_headers`.  i grepped for "._headers and found these 

```
node_modules/@types/node/http.d.ts:1
node_modules/@types/node/http2.d.ts:1
node_modules/@types/node/https.d.ts:1
node_modules/timed-out/index.js:2
node_modules/http-context/lib/response.js:1
node_modules/http-node/_http_outgoing.js:13
node_modules/http-node/_http_server.js:1
node_modules/http-node/_http_common.js:11
node_modules/typescript-transform-export-interop/node_modules/@types/node/http.d.ts:1
node_modules/typescript-transform-export-interop/node_modules/@types/node/http2.d.ts:1
node_modules/typescript-transform-export-interop/node_modules/@types/node/https.d.ts:1
node_modules/superagent/docs/test.html:10
node_modules/superagent/lib/node/index.js:4
node_modules/http-signature/lib/signer.js:6
node_modules/protobufjs/node_modules/@types/node/http.d.ts:1
node_modules/protobufjs/node_modules/@types/node/http2.d.ts:1
node_modules/http-outgoing/index.js:15
node_modules/webtorrent/webtorrent.min.js:15
node_modules/webtorrent/webtorrent.chromeapp.js:40
node_modules/videostream/dist/index.js:10
node_modules/mp4-stream/decode.js:10
```

unless these packages are updated the alternatives are limited. in this pr i just suppress all deprecation warnings for the executable.